### PR TITLE
Swap read/write order of register asm! operations

### DIFF
--- a/src/register/pc.rs
+++ b/src/register/pc.rs
@@ -5,7 +5,7 @@
 pub fn read() -> u16 {
     let r;
     unsafe {
-        asm!("mov $0,R0"
+        asm!("mov R0,$0"
              : "=r"(r)
              :
              :
@@ -17,7 +17,7 @@ pub fn read() -> u16 {
 /// Writes `bits` to the CPU register
 #[inline(always)]
 pub unsafe fn write(bits: u16) {
-    asm!("mov R0,$0"
+    asm!("mov $0,R0"
          :
          : "r"(bits)
          :

--- a/src/register/sp.rs
+++ b/src/register/sp.rs
@@ -5,7 +5,7 @@
 pub fn read() -> u16 {
     let r;
     unsafe {
-        asm!("mov $0,R1"
+        asm!("mov R1,$0"
              : "=r"(r)
              :
              :
@@ -17,7 +17,7 @@ pub fn read() -> u16 {
 /// Writes `bits` to the CPU register
 #[inline(always)]
 pub unsafe fn write(bits: u16) {
-    asm!("mov R1,$0"
+    asm!("mov $0,R1"
          :
          : "r"(bits)
          :

--- a/src/register/sr.rs
+++ b/src/register/sr.rs
@@ -77,7 +77,7 @@ impl Sr {
 pub fn read() -> Sr {
     let r: u16;
     unsafe {
-        asm!("mov $0, R2"
+        asm!("mov R2, $0"
              : "=r"(r)
              :
              :


### PR DESCRIPTION
The code to read/write MSP430 registers (for use in user code) needs to be in SRC, DEST format; it was provided in DEST, SRC format and broke AT2XT. This patch fixes the issue (tested on 6e047fb of AT2XT; I have other issues at the current tip such that I broke the firmware).